### PR TITLE
Remove use of deprecated pydantic.GenericModel

### DIFF
--- a/app/common/responses.py
+++ b/app/common/responses.py
@@ -9,7 +9,7 @@ from typing import Union
 import orjson
 from fastapi import Request
 from fastapi.responses import RedirectResponse
-from pydantic.generics import GenericModel
+from pydantic import BaseModel
 
 from app.common import json
 from app.common.errors import ServiceError
@@ -17,7 +17,7 @@ from app.common.errors import ServiceError
 T = TypeVar("T")
 
 
-class Success(GenericModel, Generic[T]):
+class Success(BaseModel, Generic[T]):
     status: Literal["success"]
     data: T
 
@@ -31,7 +31,7 @@ def success(
     return json.ORJSONResponse(data, status_code, headers)
 
 
-class ErrorResponse(GenericModel, Generic[T]):
+class ErrorResponse(BaseModel, Generic[T]):
     status: Literal["error"]
     error: T
     message: str


### PR DESCRIPTION
Noticed in the logs: https://app.datadoghq.com/logs?query=status%3Aerror%20service%3Arework-frontend%20%22pydantic.generics%3AGenericModel%22&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1718579477468&to_ts=1719875477468&live=true